### PR TITLE
Enable/Disable Apply and Cancel buttons in rangepicker when using result channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ An example LESS file that can be used to customize components can be found at `e
 * :min-date    - if set, picking a date from the past is limited by that date. Can be a date or a number of days from today.
 * :max-date    - if set, picking a date from the future is limited by that date. Can be a date or a number of days from today.
 * :first-day   - the first day of the week. Default: 1 (Monday)
+* :result-ch   - if passed, then picked values are put in that channel instead of :value key of the cursor.
+
+When `result-ch` is provided, values are put in the channel as `{:start (js/Date.) :end (js/Date.)}`
 
 ## License
 


### PR DESCRIPTION
This adds support to the `rangepicker` component to put results into a `core.async/chan`, rather than updating the app state cursor, in the same manner as the other components.

I had to add some internal state to the `rangepicker` component, mirroring the selected dates from the app state cursor, to correctly enable/disable the apply/cancel buttons. It doesn't feel ideal to keep a copy of that state, but it seemed like the simplest solution, and feels relatively straightforward.
