### PR TITLE
Fix issues with mouse events

### DIFF
--- a/src/om_datepicker/components.cljs
+++ b/src/om_datepicker/components.cljs
@@ -361,8 +361,9 @@
         (go-loop []
                  (let [[v ch] (alts! [kill-ch mouse-click-ch select-ch] :priority true)]
                    (condp = ch
-                     mouse-click-ch (let [n (om/get-node owner)]
-                                      (when-not (.contains n (.-target v))
+                     mouse-click-ch (do
+                                      (when (and (om/mounted? owner)
+                                                 (not (.contains (om/get-node owner) (.-target v))))
                                         (om/set-state! owner :expanded false))
                                       (recur))
                      select-ch      (do
@@ -459,8 +460,9 @@
                                              (om/set-state! :end   end-date)
                                              (om/set-state! :mode  :start)))
                                          (recur))
-                       mouse-click-ch  (let [n (om/get-node owner)]
-                                         (when-not (.contains n (.-target v))
+                       mouse-click-ch  (do
+                                         (when (and (om/mounted? owner)
+                                                    (not (.contains (om/get-node owner) (.-target v))))
                                            (om/set-state! owner :expanded false))
                                          (recur))
                        select-ch       (let [mode (:mode (om/get-state owner))]

--- a/src/om_datepicker/events.cljs
+++ b/src/om_datepicker/events.cljs
@@ -2,7 +2,10 @@
   (:require [cljs.core.async :as async :refer [chan put!]]
             [goog.events :as events]))
 
-(defn mouse-click []
+(defn mouse-click-listen []
   (let [ch (chan)]
-    (events/listen js/document events/EventType.CLICK #(put! ch %))
-    ch))
+    {:ch ch
+     :listener-key (events/listen js/document events/EventType.CLICK #(put! ch %))}))
+
+(defn mouse-click-unlisten [listener-key]
+  (events/unlistenByKey listener-key))


### PR DESCRIPTION
This fixes two issues that occur when using a datepicker in a context where it is unmounted and re-mounted. The commits have more detail, but this is the short version:
1. If the datepicker was unmounted as a result of a mouseclick elsewhere in the page (e.g. unchecking a checkbox), the click channel would still get a message and try to access the now-unmounted `owner` node, which would result in React throwing an error. I've added a check that guards against the error case.
2. When a datepicker is mounted, it added a click event listener to the document, but didn't remove it when unmounting. We have to explicitly remove the listener when unmounting to avoid it leaking.
